### PR TITLE
(#3) Phase 3/4: wrap correctness, retention/backpressure, and corruption-safe parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Snapshot-only recorder for CUDA device buffers. Assumptions:
 - Full snapshots only by default; delta chunks are available in Phase 2.
 - Ring buffer wrap markers are supported.
+- Retention policy supports DROP_OLDEST and BACKPRESSURE modes.
 - Chunks for an epoch are contiguous in ring order.
 - Rewind lookup scans epoch table on host.
 - No persistence; device memory only.
@@ -28,3 +29,12 @@ cmake --build build --config Release
 Demo flags:
 - `--no-delta` disables delta capture (snapshots only).
 - `--ring-bytes=<n>` overrides ring size. If too small for all epochs, rewind verification is skipped.
+
+## Recorder config
+
+`RecorderConfig` supports:
+- `retention_epochs`: keep the last N epochs (0 keeps all until space pressure).
+- `overwrite_mode`: `DROP_OLDEST` (discard old epochs to make space) or `BACKPRESSURE` (fail capture when space is insufficient).
+
+Notes:
+- `ring_bytes` must be a multiple of 32 bytes.

--- a/docs/ring_format.md
+++ b/docs/ring_format.md
@@ -1,0 +1,37 @@
+# Ring Format and WRAP Behavior
+
+## Chunk layout
+
+Each chunk starts with a 32-byte `ChunkHeader` followed by a payload:
+
+- `magic` must be `0x54545243`
+- `version` must be `1`
+- `header_bytes` must be `32`
+- `chunk_type` is one of:
+  - `kChunkTypeSnapshot`
+  - `kChunkTypeDeltaXorRle0`
+  - `kChunkTypeWrapMarker`
+
+Chunks are aligned to 32 bytes in the ring. Payloads are contiguous and never span the ring boundary.
+
+## WRAP marker chunks
+
+If an append would cross the end of the ring, the recorder writes a WRAP marker chunk at the current ring offset, pads the remainder of the ring, and continues writing the next chunk at ring offset 0. WRAP markers have:
+
+- `chunk_type = kChunkTypeWrapMarker`
+- `payload_bytes = 0`
+- `flags` includes `kChunkFlagWrapMarker`
+
+Readers must recognize WRAP markers, reset the ring offset to 0, and continue parsing without consuming an epoch chunk count.
+
+## Corruption-safe parsing checks
+
+Readers validate each header before applying:
+
+- magic/version/header size must match expected constants
+- header alignment is 32 bytes
+- payload size is non-zero for data chunks
+- payload size does not exceed ring bounds
+- chunk type is known
+
+On failure, readers return a structured error code instead of dereferencing invalid data.

--- a/include/tt/tt_layout.h
+++ b/include/tt/tt_layout.h
@@ -21,7 +21,11 @@ struct alignas(64) ControlBlock {
     uint32_t epoch_capacity;
     uint32_t region_capacity;
     uint32_t flags;
-    uint8_t padding[32];
+    uint32_t min_valid_epoch;
+    uint32_t overwrite_mode;
+    uint32_t retention_epochs;
+    uint32_t reserved0;
+    uint8_t padding[16];
 };
 
 struct alignas(32) TrackedRegion {


### PR DESCRIPTION
## Summary
- add wrap marker handling with strict parsing checks and structured errors
- implement retention/backpressure policy with atomic epoch commits and drop-oldest logic
- harden epoch index validity using generation checks
- add tiny-ring, retention, and backpressure tests
- document ring format and new config options

## Testing
- cmake --build build --config Release
- .\build\Release\tt_tests.exe

Closes #3 