### PR TITLE
Add optional CUPTI kernel tracing and merge into Chrome trace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(CUDAToolkit REQUIRED)
+option(TT_ENABLE_CUPTI "Enable CUPTI kernel tracing" OFF)
 
 add_library(ttrecorder STATIC
     src/ttrecorder.cu
@@ -21,6 +22,15 @@ target_link_libraries(ttrecorder
     PUBLIC
         CUDA::cudart
 )
+
+if(TT_ENABLE_CUPTI)
+    target_sources(ttrecorder PRIVATE src/tt_cupti.cpp)
+    target_compile_definitions(ttrecorder PUBLIC TT_ENABLE_CUPTI=1)
+    get_target_property(CUPTI_INCLUDES CUDA::cupti INTERFACE_INCLUDE_DIRECTORIES)
+    if(CUPTI_INCLUDES)
+        target_include_directories(ttrecorder PRIVATE ${CUPTI_INCLUDES})
+    endif()
+endif()
 
 add_executable(tt_demo
     demo/tt_demo.cpp

--- a/demo/tt_demo_graph.cu
+++ b/demo/tt_demo_graph.cu
@@ -1,4 +1,5 @@
 #include "tt/tt_graph.h"
+#include "tt/tt_cupti.h"
 #include "tt/tt_trace.h"
 #include "tt/ttrecorder.h"
 
@@ -43,6 +44,7 @@ bool verify_pattern(const std::vector<uint32_t>& data, uint32_t epoch) {
 } // namespace
 
 int main() {
+    tt::GetCuptiKernelTracer();
     const uint32_t element_count = 1024;
     const uint32_t size_bytes = element_count * sizeof(uint32_t);
     const uint32_t epoch_count = 8;
@@ -350,6 +352,7 @@ int main() {
         trace.add_event(epoch_regions);
     }
 
+    tt::GetCuptiKernelTracer().append_kernel_events(trace);
     trace.write("trace/tt_trace.json");
 
     if (!recorder.rewind_to_epoch(target_epoch, stream)) {

--- a/include/tt/tt_cupti.h
+++ b/include/tt/tt_cupti.h
@@ -1,0 +1,61 @@
+#ifndef TT_CUPTI_H
+#define TT_CUPTI_H
+
+#include "tt/tt_trace.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#ifdef TT_ENABLE_CUPTI
+#include <mutex>
+#endif
+
+namespace tt {
+
+#ifdef TT_ENABLE_CUPTI
+
+struct CuptiKernelEvent {
+    std::string name;
+    uint64_t start = 0;
+    uint64_t end = 0;
+    uint32_t stream_id = 0;
+    uint32_t correlation_id = 0;
+};
+
+class CuptiKernelTracer {
+public:
+    CuptiKernelTracer();
+    ~CuptiKernelTracer();
+
+    void append_kernel_events(TraceCollector& trace);
+    void clear();
+    void consume_activity_buffer(uint8_t* buffer, size_t valid_size);
+
+private:
+    std::vector<CuptiKernelEvent> events_;
+    std::mutex mutex_;
+    bool enabled_ = false;
+};
+
+CuptiKernelTracer& GetCuptiKernelTracer();
+
+#else
+
+class CuptiKernelTracer {
+public:
+    void append_kernel_events(TraceCollector&) {}
+    void clear() {}
+};
+
+inline CuptiKernelTracer& GetCuptiKernelTracer() {
+    static CuptiKernelTracer tracer;
+    return tracer;
+}
+
+#endif
+
+} // namespace tt
+
+#endif // TT_CUPTI_H

--- a/src/tt_cupti.cpp
+++ b/src/tt_cupti.cpp
@@ -1,0 +1,226 @@
+#ifdef TT_ENABLE_CUPTI
+
+#include "tt/tt_cupti.h"
+
+#include <cupti.h>
+#include <cupti_activity.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <utility>
+#include <windows.h>
+
+namespace tt {
+
+namespace {
+
+constexpr size_t kBufferSize = 16 * 1024;
+
+CuptiKernelTracer* g_tracer_ptr = nullptr;
+
+struct CuptiApi {
+    using RegisterCallbacksFn = CUptiResult(CUPTIAPI*)(CUpti_BuffersCallbackRequestFunc,
+        CUpti_BuffersCallbackCompleteFunc);
+    using EnableFn = CUptiResult(CUPTIAPI*)(CUpti_ActivityKind);
+    using DisableFn = CUptiResult(CUPTIAPI*)(CUpti_ActivityKind);
+    using FlushAllFn = CUptiResult(CUPTIAPI*)(uint32_t);
+    using GetNextRecordFn = CUptiResult(CUPTIAPI*)(uint8_t*, size_t, CUpti_Activity**);
+    using GetDroppedFn = CUptiResult(CUPTIAPI*)(CUcontext, uint32_t, size_t*);
+
+    HMODULE module = nullptr;
+    RegisterCallbacksFn register_callbacks = nullptr;
+    EnableFn enable = nullptr;
+    DisableFn disable = nullptr;
+    FlushAllFn flush_all = nullptr;
+    GetNextRecordFn get_next_record = nullptr;
+    GetDroppedFn get_num_dropped = nullptr;
+
+    bool load() {
+        if (module) {
+            return true;
+        }
+        char cuda_path[MAX_PATH] = {};
+        DWORD len = GetEnvironmentVariableA("CUDA_PATH", cuda_path, MAX_PATH);
+        if (len > 0 && len < MAX_PATH) {
+            std::string pattern = std::string(cuda_path) + "\\extras\\CUPTI\\lib64\\cupti64_*.dll";
+            WIN32_FIND_DATAA data{};
+            HANDLE handle = FindFirstFileA(pattern.c_str(), &data);
+            if (handle != INVALID_HANDLE_VALUE) {
+                std::string full_path = std::string(cuda_path) + "\\extras\\CUPTI\\lib64\\" + data.cFileName;
+                FindClose(handle);
+                module = LoadLibraryA(full_path.c_str());
+            }
+        }
+        if (!module) {
+            module = LoadLibraryA("cupti64.dll");
+        }
+        if (!module) {
+            return false;
+        }
+
+        register_callbacks = reinterpret_cast<RegisterCallbacksFn>(
+            GetProcAddress(module, "cuptiActivityRegisterCallbacks"));
+        enable = reinterpret_cast<EnableFn>(GetProcAddress(module, "cuptiActivityEnable"));
+        disable = reinterpret_cast<DisableFn>(GetProcAddress(module, "cuptiActivityDisable"));
+        flush_all = reinterpret_cast<FlushAllFn>(GetProcAddress(module, "cuptiActivityFlushAll"));
+        get_next_record = reinterpret_cast<GetNextRecordFn>(
+            GetProcAddress(module, "cuptiActivityGetNextRecord"));
+        get_num_dropped = reinterpret_cast<GetDroppedFn>(
+            GetProcAddress(module, "cuptiActivityGetNumDroppedRecords"));
+
+        if (!register_callbacks || !enable || !disable || !flush_all || !get_next_record || !get_num_dropped) {
+            FreeLibrary(module);
+            module = nullptr;
+            return false;
+        }
+        return true;
+    }
+};
+
+CuptiApi& GetCuptiApi() {
+    static CuptiApi api;
+    return api;
+}
+
+void CUPTIAPI buffer_requested(uint8_t** buffer, size_t* size, size_t* max_num_records) {
+    if (!buffer || !size || !max_num_records) {
+        return;
+    }
+    *size = kBufferSize;
+    *buffer = static_cast<uint8_t*>(std::malloc(*size));
+    *max_num_records = 0;
+}
+
+void CUPTIAPI buffer_completed(CUcontext ctx, uint32_t stream_id, uint8_t* buffer, size_t size, size_t valid_size) {
+    if (g_tracer_ptr && buffer && valid_size > 0) {
+        g_tracer_ptr->consume_activity_buffer(buffer, valid_size);
+    }
+    if (buffer) {
+        std::free(buffer);
+    }
+    size_t dropped = 0;
+    CuptiApi& api = GetCuptiApi();
+    if (api.get_num_dropped) {
+        (void)api.get_num_dropped(ctx, stream_id, &dropped);
+    }
+}
+
+} // namespace
+
+CuptiKernelTracer::CuptiKernelTracer() {
+    g_tracer_ptr = this;
+    CuptiApi& api = GetCuptiApi();
+    if (!api.load()) {
+        enabled_ = false;
+        return;
+    }
+    if (api.register_callbacks(buffer_requested, buffer_completed) != CUPTI_SUCCESS) {
+        enabled_ = false;
+        return;
+    }
+    if (api.enable(CUPTI_ACTIVITY_KIND_KERNEL) != CUPTI_SUCCESS) {
+        enabled_ = false;
+        return;
+    }
+    if (api.enable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL) != CUPTI_SUCCESS) {
+        enabled_ = false;
+        return;
+    }
+    enabled_ = true;
+}
+
+CuptiKernelTracer::~CuptiKernelTracer() {
+    if (enabled_) {
+        CuptiApi& api = GetCuptiApi();
+        api.flush_all(0);
+        api.disable(CUPTI_ACTIVITY_KIND_KERNEL);
+        api.disable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL);
+    }
+    g_tracer_ptr = nullptr;
+}
+
+void CuptiKernelTracer::clear() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    events_.clear();
+}
+
+void CuptiKernelTracer::consume_activity_buffer(uint8_t* buffer, size_t valid_size) {
+    CUpti_Activity* record = nullptr;
+    CuptiApi& api = GetCuptiApi();
+    if (!api.get_next_record) {
+        return;
+    }
+    while (api.get_next_record(buffer, valid_size, &record) == CUPTI_SUCCESS) {
+        if (!record) {
+            continue;
+        }
+        if (record->kind != CUPTI_ACTIVITY_KIND_KERNEL &&
+            record->kind != CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL) {
+            continue;
+        }
+        const auto* kernel = reinterpret_cast<const CUpti_ActivityKernel4*>(record);
+        CuptiKernelEvent event{};
+        if (kernel->name) {
+            event.name = kernel->name;
+        }
+        event.start = kernel->start;
+        event.end = kernel->end;
+        event.stream_id = kernel->streamId;
+        event.correlation_id = kernel->correlationId;
+        std::lock_guard<std::mutex> lock(mutex_);
+        events_.push_back(std::move(event));
+    }
+}
+
+void CuptiKernelTracer::append_kernel_events(TraceCollector& trace) {
+    if (!enabled_) {
+        return;
+    }
+
+    CuptiApi& api = GetCuptiApi();
+    if (api.flush_all) {
+        api.flush_all(0);
+    }
+
+    std::vector<CuptiKernelEvent> snapshot;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (events_.empty()) {
+            return;
+        }
+        snapshot.swap(events_);
+    }
+
+    uint64_t base_start = snapshot[0].start;
+    for (const auto& event : snapshot) {
+        base_start = std::min(base_start, event.start);
+    }
+
+    for (const auto& event : snapshot) {
+        if (event.end <= event.start) {
+            continue;
+        }
+        TraceEvent trace_event{};
+        trace_event.name = event.name.empty() ? "kernel" : event.name;
+        trace_event.cat = "kernel";
+        trace_event.ts_us = static_cast<double>(event.start - base_start) / 1000.0;
+        trace_event.dur_us = static_cast<double>(event.end - event.start) / 1000.0;
+        trace_event.pid = 1;
+        trace_event.tid = static_cast<int>(event.stream_id);
+        if (event.correlation_id != 0) {
+            trace_event.args.push_back({"correlation_id", std::to_string(event.correlation_id), false});
+        }
+        trace.add_event(trace_event);
+    }
+}
+
+CuptiKernelTracer& GetCuptiKernelTracer() {
+    static CuptiKernelTracer tracer;
+    return tracer;
+}
+
+} // namespace tt
+
+#endif

--- a/tests/tt_tests.cu
+++ b/tests/tt_tests.cu
@@ -1,4 +1,5 @@
 #include "tt/tt_graph.h"
+#include "tt/tt_cupti.h"
 #include "tt/tt_trace.h"
 #include "tt/ttrecorder.h"
 
@@ -871,6 +872,7 @@ bool test_graph_capture_and_trace() {
     }
 
     trace.add_event({"graph_launch", "graph", 0.0, 1.0, 1, 0, {{"epoch_id", "0", false}}});
+    tt::GetCuptiKernelTracer().append_kernel_events(trace);
     trace.write("trace/tt_trace.json");
 
     const bool valid_trace = trace_json_valid("trace/tt_trace.json");
@@ -887,6 +889,7 @@ bool test_graph_capture_and_trace() {
 } // namespace
 
 int main() {
+    tt::GetCuptiKernelTracer();
     bool ok_single = test_single_region();
     if (!ok_single) {
         std::printf("test_single_region failed\n");


### PR DESCRIPTION
Adds optional TT_ENABLE_CUPTI build flag and CUPTI kernel
  tracer with RAII startup, merges kernel events into trace output, and keeps default builds unchanged. Updates demo and tests to append kernel
  events. Handles missing CUPTI DLLs at runtime. Closes #7.