### PR TITLE
Phase 10: Multi-stream capture dependencies with GPU-side causality proof

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,12 @@ add_executable(tt_demo_graph_patch
 
 target_link_libraries(tt_demo_graph_patch PRIVATE ttrecorder)
 
+add_executable(tt_demo_multistream_stress
+    demo/tt_demo_multistream_stress.cu
+)
+
+target_link_libraries(tt_demo_multistream_stress PRIVATE ttrecorder)
+
 add_executable(tt_tests
     tests/tt_tests.cu
 )

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ cmake --build build --config Release
 .\build\Release\tt_demo_graph.exe
 .\build\Release\tt_demo_graph_patch.exe
 .\build\Release\tt_demo_determinism.exe
+.\build\Release\tt_demo_multistream_stress.exe --deps
+.\build\Release\tt_demo_multistream_stress.exe --no-deps
 .\build\Release\tt_tests.exe
 ```
 
@@ -61,6 +63,19 @@ start chrome "chrome://tracing"
 
 Notes:
 - `ring_bytes` must be a multiple of 32 bytes.
+
+## Multi-stream correctness
+
+When producers write tracked regions on different streams, the capture stream should wait on a producer-completed event per region. Without dependencies, captures can observe partially-written data. The recorder supports per-region dependencies via `CaptureDeps` and `cudaStreamWaitEvent`.
+
+See `docs/multistream.md` for the dependency model, trace stamps, and a minimal code snippet.
+
+Example commands:
+
+```
+.\build\Release\tt_demo_multistream_stress.exe --deps
+.\build\Release\tt_demo_multistream_stress.exe --no-deps
+```
 
 ## Deterministic replay mode
 

--- a/demo/tt_demo_multistream_stress.cu
+++ b/demo/tt_demo_multistream_stress.cu
@@ -1,0 +1,383 @@
+#include "tt/tt_trace.h"
+#include "tt/ttrecorder.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+bool check_cuda(cudaError_t err, const char* label) {
+    if (err == cudaSuccess) {
+        return true;
+    }
+    std::printf("CUDA error at %s: %s\n", label, cudaGetErrorString(err));
+    return false;
+}
+
+__host__ __device__ uint32_t pattern_value(uint32_t epoch, uint32_t seed, uint32_t idx) {
+    return epoch ^ seed ^ (idx * 2654435761u);
+}
+
+__host__ __device__ uint32_t commit_value(uint32_t epoch, uint32_t seed) {
+    return epoch ^ seed ^ 0xA5A5A5A5u;
+}
+
+__global__ void write_region_phased_kernel(uint32_t* data,
+    uint32_t count,
+    uint32_t epoch,
+    uint32_t seed,
+    uint32_t spin_cycles) {
+    const uint32_t idx = threadIdx.x;
+    if (idx >= count) {
+        return;
+    }
+    const uint32_t commit_index = count - 1u;
+    const uint32_t half = commit_index / 2u;
+
+    if (idx < commit_index && idx < half) {
+        data[idx] = pattern_value(epoch, seed, idx);
+    }
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+        const uint64_t start = clock64();
+        while ((clock64() - start) < static_cast<uint64_t>(spin_cycles)) {
+        }
+    }
+    __syncthreads();
+
+    if (idx < commit_index && idx >= half) {
+        data[idx] = pattern_value(epoch, seed, idx);
+    }
+    __syncthreads();
+
+    if (idx == commit_index) {
+        data[idx] = commit_value(epoch, seed);
+    }
+}
+
+bool verify_region(const std::vector<uint32_t>& data, uint32_t epoch, uint32_t seed) {
+    if (data.size() < 2) {
+        return false;
+    }
+    const uint32_t commit_index = static_cast<uint32_t>(data.size() - 1);
+    for (uint32_t i = 0; i < commit_index; ++i) {
+        const uint32_t expected = pattern_value(epoch, seed, i);
+        if (data[i] != expected) {
+            return false;
+        }
+    }
+    return data[commit_index] == commit_value(epoch, seed);
+}
+
+std::string hex_ptr(uint64_t value) {
+    std::ostringstream out;
+    out << "0x" << std::hex << value;
+    return out.str();
+}
+
+uint32_t parse_u32(const char* arg, const char* prefix, uint32_t fallback) {
+    const size_t prefix_len = std::strlen(prefix);
+    if (std::strncmp(arg, prefix, prefix_len) != 0) {
+        return fallback;
+    }
+    return static_cast<uint32_t>(std::strtoul(arg + prefix_len, nullptr, 10));
+}
+
+} // namespace
+
+int main() {
+    bool use_deps = true;
+    uint32_t epoch_count = 64;
+    uint32_t verify_count = 8;
+    uint32_t spin_cycles = 200000;
+    std::string trace_path = "trace/tt_multistream_deps.json";
+
+    for (int i = 1; i < __argc; ++i) {
+        if (std::strcmp(__argv[i], "--no-deps") == 0) {
+            use_deps = false;
+            trace_path = "trace/tt_multistream_no_deps.json";
+        } else if (std::strcmp(__argv[i], "--deps") == 0) {
+            use_deps = true;
+            trace_path = "trace/tt_multistream_deps.json";
+        } else if (std::strncmp(__argv[i], "--epochs=", 9) == 0) {
+            epoch_count = parse_u32(__argv[i], "--epochs=", epoch_count);
+        } else if (std::strncmp(__argv[i], "--verify=", 9) == 0) {
+            verify_count = parse_u32(__argv[i], "--verify=", verify_count);
+        } else if (std::strncmp(__argv[i], "--spin=", 7) == 0) {
+            spin_cycles = parse_u32(__argv[i], "--spin=", spin_cycles);
+        } else if (std::strncmp(__argv[i], "--trace-out=", 12) == 0) {
+            trace_path = __argv[i] + 12;
+        }
+    }
+
+    const uint32_t region_count = 3;
+    const uint32_t element_count = 256;
+    const uint32_t size_bytes = element_count * sizeof(uint32_t);
+    const uint32_t block_threads = element_count;
+
+    cudaStream_t producer_streams[region_count]{};
+    cudaEvent_t producer_events[region_count]{};
+    for (uint32_t i = 0; i < region_count; ++i) {
+        if (!check_cuda(cudaStreamCreate(&producer_streams[i]), "stream create")) {
+            return 1;
+        }
+        if (!check_cuda(cudaEventCreateWithFlags(&producer_events[i], cudaEventDisableTiming), "event create")) {
+            return 1;
+        }
+    }
+    cudaStream_t capture_stream = nullptr;
+    if (!check_cuda(cudaStreamCreate(&capture_stream), "capture stream create")) {
+        return 1;
+    }
+
+    void* d_regions[region_count]{};
+    for (uint32_t i = 0; i < region_count; ++i) {
+        if (!check_cuda(cudaMalloc(&d_regions[i], size_bytes), "cudaMalloc region")) {
+            return 1;
+        }
+    }
+
+    uint64_t* d_dep_stamps = nullptr;
+    uint32_t* d_dep_stamp_counter = nullptr;
+    const uint32_t dep_count = region_count;
+    const uint32_t dep_stamps_needed = epoch_count * dep_count * 2u;
+    if (use_deps) {
+        if (!check_cuda(cudaMalloc(&d_dep_stamps, sizeof(uint64_t) * dep_stamps_needed), "cudaMalloc dep stamps") ||
+            !check_cuda(cudaMalloc(&d_dep_stamp_counter, sizeof(uint32_t)), "cudaMalloc dep stamp counter")) {
+            return 1;
+        }
+        if (!check_cuda(cudaMemset(d_dep_stamp_counter, 0, sizeof(uint32_t)), "memset dep stamp counter")) {
+            return 1;
+        }
+    }
+
+    tt::Recorder recorder;
+    tt::RecorderConfig cfg{};
+    cfg.ring_bytes = size_bytes * region_count * (epoch_count + 2u) + 4096u;
+    cfg.epoch_capacity = epoch_count + 4u;
+    cfg.region_capacity = region_count;
+    cfg.retention_epochs = 0;
+    cfg.overwrite_mode = tt::OverwriteMode::kDropOldest;
+    cfg.enable_dep_stamps = use_deps;
+    cfg.dep_stamps = d_dep_stamps;
+    cfg.dep_stamp_counter = d_dep_stamp_counter;
+    cfg.dep_stamp_capacity = use_deps ? dep_stamps_needed : 0u;
+    if (!recorder.init(cfg)) {
+        std::printf("recorder init failed\n");
+        return 1;
+    }
+
+    for (uint32_t i = 0; i < region_count; ++i) {
+        if (!recorder.register_region(i, d_regions[i], size_bytes, 1)) {
+            std::printf("register_region failed\n");
+            return 1;
+        }
+    }
+
+    std::vector<double> capture_submit_us;
+    capture_submit_us.reserve(epoch_count);
+    const auto trace_start = std::chrono::steady_clock::now();
+
+    const uint32_t seeds[region_count] = {0x11110000u, 0x22220000u, 0x33330000u};
+    tt::CaptureDependency deps[region_count]{};
+
+    for (uint32_t epoch = 0; epoch < epoch_count; ++epoch) {
+        for (uint32_t r = 0; r < region_count; ++r) {
+            write_region_phased_kernel<<<1, block_threads, 0, producer_streams[r]>>>(
+                static_cast<uint32_t*>(d_regions[r]),
+                element_count,
+                epoch,
+                seeds[r],
+                spin_cycles);
+            if (!check_cuda(cudaGetLastError(), "launch write_region_phased_kernel")) {
+                return 1;
+            }
+            if (!check_cuda(cudaEventRecord(producer_events[r], producer_streams[r]), "event record")) {
+                return 1;
+            }
+        }
+
+        const auto submit_time = std::chrono::steady_clock::now();
+        if (use_deps) {
+            for (uint32_t r = 0; r < region_count; ++r) {
+                deps[r].region_id = r;
+                deps[r].event = producer_events[r];
+                deps[r].producer_stream = producer_streams[r];
+            }
+            tt::CaptureDeps dep_list{deps, region_count};
+            if (!recorder.capture_epoch(capture_stream, dep_list)) {
+                std::printf("capture_epoch failed at %u\n", epoch);
+                return 1;
+            }
+        } else {
+            if (!recorder.capture_epoch(capture_stream)) {
+                std::printf("capture_epoch failed at %u\n", epoch);
+                return 1;
+            }
+        }
+        const double submit_us = std::chrono::duration<double, std::micro>(submit_time - trace_start).count();
+        capture_submit_us.push_back(submit_us);
+
+        for (uint32_t r = 0; r < region_count; ++r) {
+            if (!check_cuda(cudaStreamSynchronize(producer_streams[r]), "producer sync")) {
+                return 1;
+            }
+        }
+    }
+
+    std::vector<uint32_t> host_region(element_count);
+    std::mt19937 rng(0xC0FFEEu);
+    std::uniform_int_distribution<uint32_t> dist(0, epoch_count - 1u);
+    uint32_t mismatches = 0;
+    const uint32_t checks = (verify_count > epoch_count) ? epoch_count : verify_count;
+    for (uint32_t i = 0; i < checks; ++i) {
+        const uint32_t epoch = dist(rng);
+        if (!recorder.rewind_to_epoch(epoch, capture_stream)) {
+            std::printf("rewind_to_epoch failed at %u\n", epoch);
+            return 1;
+        }
+        for (uint32_t r = 0; r < region_count; ++r) {
+            if (!check_cuda(cudaMemcpy(host_region.data(), d_regions[r], size_bytes, cudaMemcpyDeviceToHost), "memcpy region")) {
+                return 1;
+            }
+            if (!verify_region(host_region, epoch, seeds[r])) {
+                ++mismatches;
+                break;
+            }
+        }
+    }
+
+    tt::TraceCollector trace;
+    if (use_deps) {
+        uint32_t stamp_count = 0;
+        if (!check_cuda(cudaMemcpy(&stamp_count, d_dep_stamp_counter, sizeof(uint32_t), cudaMemcpyDeviceToHost), "memcpy dep stamp count")) {
+            return 1;
+        }
+        std::vector<uint64_t> host_stamps(stamp_count, 0u);
+        if (stamp_count > 0) {
+            if (!check_cuda(cudaMemcpy(host_stamps.data(), d_dep_stamps, sizeof(uint64_t) * stamp_count, cudaMemcpyDeviceToHost), "memcpy dep stamps")) {
+                return 1;
+            }
+        }
+
+        int clock_rate_khz = 0;
+        if (!check_cuda(cudaDeviceGetAttribute(&clock_rate_khz, cudaDevAttrClockRate, 0), "device clock rate")) {
+            return 1;
+        }
+        const double cycles_to_us = 1000.0 / static_cast<double>(clock_rate_khz);
+
+        uint64_t base_stamp = 0;
+        bool base_set = false;
+        for (const auto& wait : recorder.dep_wait_records()) {
+            if (wait.stamp_index_begin >= host_stamps.size() || wait.stamp_index_end >= host_stamps.size()) {
+                continue;
+            }
+            const uint64_t begin_stamp = host_stamps[wait.stamp_index_begin];
+            if (!base_set || begin_stamp < base_stamp) {
+                base_stamp = begin_stamp;
+                base_set = true;
+            }
+        }
+
+        std::vector<uint64_t> epoch_min_stamp(epoch_count, 0);
+        std::vector<bool> epoch_seen(epoch_count, false);
+        for (const auto& wait : recorder.dep_wait_records()) {
+            if (wait.epoch_id >= epoch_count) {
+                continue;
+            }
+            if (wait.stamp_index_begin >= host_stamps.size() || wait.stamp_index_end >= host_stamps.size()) {
+                continue;
+            }
+            const uint64_t begin_stamp = host_stamps[wait.stamp_index_begin];
+            const uint64_t end_stamp = host_stamps[wait.stamp_index_end];
+            if (!base_set) {
+                base_stamp = begin_stamp;
+                base_set = true;
+            }
+
+            if (!epoch_seen[wait.epoch_id] || begin_stamp < epoch_min_stamp[wait.epoch_id]) {
+                epoch_min_stamp[wait.epoch_id] = begin_stamp;
+                epoch_seen[wait.epoch_id] = true;
+            }
+
+            tt::TraceEvent event{};
+            event.name = "wait_event";
+            event.cat = "deps";
+            event.ts_us = static_cast<double>(begin_stamp - base_stamp) * cycles_to_us;
+            event.dur_us = static_cast<double>(end_stamp - begin_stamp) * cycles_to_us;
+            event.pid = 1;
+            event.tid = 0;
+            event.args.push_back({"epoch_id", std::to_string(wait.epoch_id), false});
+            event.args.push_back({"region_id", std::to_string(wait.region_id), false});
+            event.args.push_back({"stream_id_capture", std::to_string(wait.capture_stream), false});
+            if (wait.producer_stream != 0u) {
+                event.args.push_back({"stream_id_producer", std::to_string(wait.producer_stream), false});
+            }
+            event.args.push_back({"event_ptr", hex_ptr(wait.event_ptr), true});
+            trace.add_event(event);
+        }
+
+        for (uint32_t epoch = 0; epoch < epoch_count; ++epoch) {
+            if (!epoch_seen[epoch]) {
+                continue;
+            }
+            tt::TraceEvent submit{};
+            submit.name = "capture_epoch_submit";
+            submit.cat = "deps";
+            submit.ts_us = static_cast<double>(epoch_min_stamp[epoch] - base_stamp) * cycles_to_us;
+            submit.dur_us = 0.0;
+            submit.pid = 1;
+            submit.tid = 0;
+            submit.args.push_back({"epoch_id", std::to_string(epoch), false});
+            trace.add_event(submit);
+        }
+    } else {
+        for (uint32_t epoch = 0; epoch < capture_submit_us.size(); ++epoch) {
+            tt::TraceEvent submit{};
+            submit.name = "capture_epoch_submit";
+            submit.cat = "deps";
+            submit.ts_us = capture_submit_us[epoch];
+            submit.dur_us = 0.0;
+            submit.pid = 1;
+            submit.tid = 0;
+            submit.args.push_back({"epoch_id", std::to_string(epoch), false});
+            trace.add_event(submit);
+        }
+    }
+
+    trace.write(trace_path.c_str());
+
+    recorder.shutdown();
+    for (uint32_t r = 0; r < region_count; ++r) {
+        cudaFree(d_regions[r]);
+    }
+    if (use_deps) {
+        cudaFree(d_dep_stamp_counter);
+        cudaFree(d_dep_stamps);
+    }
+    for (uint32_t r = 0; r < region_count; ++r) {
+        cudaEventDestroy(producer_events[r]);
+        cudaStreamDestroy(producer_streams[r]);
+    }
+    cudaStreamDestroy(capture_stream);
+
+    if (!use_deps) {
+        std::printf("no-deps mismatches: %u\n", mismatches);
+        std::printf("trace written: %s\n", trace_path.c_str());
+        return 0;
+    }
+    if (mismatches > 0u) {
+        std::printf("deps mode mismatches: %u\n", mismatches);
+        return 1;
+    }
+
+    std::printf("deps mode success (trace written: %s)\n", trace_path.c_str());
+    return 0;
+}

--- a/docs/multistream.md
+++ b/docs/multistream.md
@@ -1,0 +1,55 @@
+# Multi-stream capture correctness
+
+This project supports per-region dependencies for capture epochs. The dependency model makes capture ordering explicit and avoids observing partially-written data when producers run on different streams.
+
+## Dependency model
+
+- Producers write into tracked regions on their own streams.
+- Each producer records a `cudaEvent_t` after the region update completes.
+- The capture stream waits on that event before reading the region.
+- The wait is scheduled with `cudaStreamWaitEvent` on the capture stream (no host blocking).
+
+Without dependencies, the capture stream may read a region while a producer is still writing it, which can yield partially-updated snapshots or deltas.
+
+## Minimal usage
+
+```cpp
+cudaStream_t producer = nullptr;
+cudaStream_t capture = nullptr;
+cudaEvent_t done = nullptr;
+
+cudaStreamCreate(&producer);
+cudaStreamCreate(&capture);
+cudaEventCreateWithFlags(&done, cudaEventDisableTiming);
+
+// Launch producer work for region 0.
+write_region_kernel<<<grid, block, 0, producer>>>(region_ptr, ...);
+cudaEventRecord(done, producer);
+
+tt::CaptureDependency dep{};
+dep.region_id = 0;
+dep.event = done;
+dep.producer_stream = producer;
+
+tt::CaptureDeps deps{&dep, 1};
+recorder.capture_epoch(capture, deps);
+```
+
+## Trace and stamps
+
+If you enable dependency stamps in `RecorderConfig` (`enable_dep_stamps`, `dep_stamps`, `dep_stamp_counter`, `dep_stamp_capacity`), the recorder emits GPU clock stamps before/after each wait. These stamps can be converted into Chrome trace events. See the demo below for a full example that produces `wait_event` traces with per-region metadata.
+
+## Determinism interaction
+
+Deterministic mode pins captures to a single stream. Multi-stream producers are still allowed, but capture itself is serialized and will wait on dependencies in that fixed stream. If you need maximum concurrency, keep deterministic mode off.
+
+## Demo
+
+`tt_demo_multistream_stress` shows dependency waits and correctness under concurrent producers:
+
+- `tt_demo_multistream_stress --deps` records with per-region dependencies and validates correctness.
+- `tt_demo_multistream_stress --no-deps` records without dependencies and reports any mismatches it finds.
+
+## Test scaling
+
+The multistream tests honor `TT_TEST_MULTISTREAM_ITERS` to reduce the number of epochs when needed.


### PR DESCRIPTION
This PR implements Phase 10 multi-stream capture correctness by adding per-region dependency handling with GPU-side event waits and trace stamps, plus stress demos and deterministic tests that prove both failure without dependencies and correctness with dependencies.

The work closes Issue #13.

Summary
- Added per-region capture dependencies with CUDA event waits enforced on the capture stream.
- Added GPU wait stamps and trace metadata to provide causality proof in Chrome trace output.
- Added a multi-stream stress demo with deps and no-deps modes to demonstrate correctness and failure cases.
- Added deterministic tests that reliably fail without deps and pass with deps.
- Updated documentation and README to describe the dependency model, trace stamps, and usage.

Key changes
- New dependency API and dep-stamp plumbing in `include/tt/ttrecorder.h` and `src/ttrecorder.cu`, including validation, stream waits, and DepWaitRecord metadata for trace output.
- New stress demo in `demo/tt_demo_multistream_stress.cu` supporting deps and no-deps modes, wired via CMakeLists.txt.
- Deterministic multi-stream tests in `tests/tt_tests.cu` covering no-deps failure, deps success, and multi-region scenarios, with iteration scaling via `TT_TEST_MULTISTREAM_ITERS`.
- Documentation updates in docs/multistream.md and README.md describing the dependency model and how to interpret trace output.

Build and run (Windows)
```
cmake --build build --config Release
.\build\Release\tt_demo_multistream_stress.exe --deps
.\build\Release\tt_demo_multistream_stress.exe --no-deps
.\build\Release\tt_tests.exe
```

Tests run
- `cmake --build build --config Release`
- `.\build\Release\tt_tests.exe`

Exit criteria
- Trace output shows non-zero GPU wait durations for per-region dependencies.
- Capture with dependencies is always correct under concurrent producer streams.
- Capture without dependencies reliably demonstrates incorrect behavior.
- All tests pass deterministically.

Closes #13